### PR TITLE
Drop Hashie::Mash to silence key conflict warnings

### DIFF
--- a/lib/mini_apivore/swagger.rb
+++ b/lib/mini_apivore/swagger.rb
@@ -3,7 +3,9 @@ require 'hashie'
 
 
 module MiniApivore
-  class Swagger < Hashie::Mash
+  class Swagger < Hash
+    include Hashie::Extensions::MergeInitializer
+
     NONVERB_PATH_ITEMS = %q(parameters)
 
     def validate
@@ -17,7 +19,7 @@ module MiniApivore
     end
 
     def version
-      swagger
+      self['swagger']
     end
 
     def base_path
@@ -25,18 +27,18 @@ module MiniApivore
     end
 
     def each_response(&block)
-      paths.each do |path, path_data|
+      self['paths'].each do |path, path_data|
         next if vendor_specific_tag? path
         path_data.each do |verb, method_data|
           next if NONVERB_PATH_ITEMS.include?(verb)
           next if vendor_specific_tag? verb
-          if method_data.responses.nil?
+          if method_data['responses'].nil?
             raise "No responses found in swagger for path '#{path}', " \
               "verb #{verb}: #{method_data.inspect}"
           end
-          method_data.responses.each do |response_code, response_data|
+          method_data['responses'].each do |response_code, response_data|
             schema_location = nil
-            if response_data.schema
+            if response_data['schema']
               schema_location = Fragment.new ['#', 'paths', path, verb, 'responses', response_code, 'schema']
             end
             block.call(path, verb, response_code, schema_location)


### PR DESCRIPTION
Hashie::Mash complained that some keys found in the Swagger schema conflicted with Hash or Swagger methods.

See:

```
W, [2022-03-29T08:47:43.004712 #3777]  WARN -- : You are setting a key that conflicts with a built-in method MiniApivore::Swagger#version defined at .../mini-apivore-0.1.8/lib/mini_apivore/swagger.rb:19. This can cause unexpected behavior when accessing he key as a property. You can still access the key via the #[] method.
W, [2022-03-29T08:47:43.006017 #3777]  WARN -- : You are setting a key that conflicts with a built-in method MiniApivore::Swagger#delete defined at .../hashie-3.6.0/lib/hashie/mash.rb:178. This can cause unexpected behavior when accessing the key as a property. You can still access the key via the #[] method.
W, [2022-03-29T08:47:43.006588 #3777]  WARN -- : You are setting a key that conflicts with a built-in method MiniApivore::Swagger#default defined in Hash. This can cause unexpected behavior when accessing the key as a property. You can still access the key via the #[] method.
[...]
```